### PR TITLE
Fix deprecation for the latest Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Contains source code for the FT_EXPLAINED web application.
 The main Python code is inside "flask_app.py" file.
 Web pages are in "templates" directory, and style sheets in "static" directory.
 The app needs these requirements:
-1. Python 
-2. Matplotlib 
-3. Numpy
-4. Scipy
-5. Flask 
+1. [Python](https://www.python.org)
+2. [Matplotlib](https://matplotlib.org)
+3. [Numpy](https://numpy.org)
+4. [Scipy](https://scipy.org)
+5. [Flask](https://flask.palletsprojects.com/)
 
 ## Install with your PC as local host
 ### First, install python

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The app needs these requirements:
 3. [Numpy](https://numpy.org)
 4. [Scipy](https://scipy.org)
 5. [Flask](https://flask.palletsprojects.com/)
+
 (All has been tested successful on `Python 3.13.2` and the latest version of these libs.) 
 ## Install with your PC as local host
 ### First, install python

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # FT_EXPLAINED
-This Program is to explain how Fourier Transform is used in NMR. 
+This Program is to explain how Fourier Transfer is used in NMR. 
 The repository contains source code for the FT_EXPLAINED web application.
 The main program together with its Python code is inside `flask_app.py` file.
 Web pages are in "templates" directory, and style sheets in "static" directory.

--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ You can install these package using your package manager.
 ### Finally run the program as a host
 Run `flask_app.py` and open the link in the browser ( such as 
 `http://127.0.0.1:5000` ) and enjoy!
+
+## Screenshots
+![image](https://github.com/user-attachments/assets/50cdd28a-b9bf-4e51-93c4-4b235f389510)
+After Installation, it will work like this.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,32 @@ Contains source code for the FT_EXPLAINED web application.
 The main Python code is inside "flask_app.py" file.
 Web pages are in "templates" directory, and style sheets in "static" directory.
 The app needs these requirements:
-Python 3.7.3 - 
-Matplotlib 3.1.0 - 
-Flask 1.0.3 
+Python 3.7.3 or any version later 
+Matplotlib 3.1.0 or any version later 
+Flask 1.0.3 or any version later
+
+## Install with your PC as local host
+### First, install python
+If you are a Windows user, install python at 
+[this](https://www.python.org/downloads/) page.\
+**If this is the first time to install python on Windows,
+it is recommended to select
+`Add python.exe to PATH` at the first installation step**
+
+If Linux, it is recommanded to use distro's package manager.
+
+### Then, install libraries
+For Windows users,
+first ensure python is in your `Path` Environment Variable,
+then you can start `cmd` and run this command:
+```sh
+pip install numpy scipy matplotlib flask
+```
+Wait for a moment and all will be done automatically.
+
+For Linux users,
+You can install these package using your package manager.
+
+### Finally run the program as a host
+Run `flask_app.py` and open the link in the browser ( such as 
+`http://127.0.0.1:5000` ) and enjoy!

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Contains source code for the FT_EXPLAINED web application.
 The main Python code is inside "flask_app.py" file.
 Web pages are in "templates" directory, and style sheets in "static" directory.
 The app needs these requirements:
-Python 3.7.3 or any version later 
-Matplotlib 3.1.0 or any version later 
-Flask 1.0.3 or any version later
+1. Python 3.7.3 or any version later 
+2. Matplotlib 3.1.0 or any version later 
+3. Flask 1.0.3 or any version later
 
 ## Install with your PC as local host
 ### First, install python

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The app needs these requirements:
 3. [Numpy](https://numpy.org)
 4. [Scipy](https://scipy.org)
 5. [Flask](https://flask.palletsprojects.com/)
-
+(All has been tested successful on `Python 3.13.2` and the latest version of these libs.) 
 ## Install with your PC as local host
 ### First, install python
 If you are a Windows user, install python at 

--- a/README.md
+++ b/README.md
@@ -42,3 +42,9 @@ Run `flask_app.py` and open the link in the browser ( such as
 ## Screenshots
 ![image](https://github.com/user-attachments/assets/50cdd28a-b9bf-4e51-93c4-4b235f389510)
 After Installation, it will work like this.
+
+## References
+The author's paper is available on [THIS](https://pubs.acs.org/doi/10.1021/acs.jchemed.9b00502)
+site.\
+DOI link: [https://doi.org/10.1021/acs.jchemed.9b00502](https://doi.org/10.1021/acs.jchemed.9b00502)\
+Cite this: J. Chem. Educ. 2020, 97, 1, 263–264

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@ Contains source code for the FT_EXPLAINED web application.
 The main Python code is inside "flask_app.py" file.
 Web pages are in "templates" directory, and style sheets in "static" directory.
 The app needs these requirements:
-1. Python 3.7.3 or any version later 
-2. Matplotlib 3.1.0 or any version later 
-3. Flask 1.0.3 or any version later
+1. Python 
+2. Matplotlib 
+3. Numpy
+4. Scipy
+5. Flask 
 
 ## Install with your PC as local host
 ### First, install python

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ For Linux users,
 You can install these package using your package manager.
 
 ### Finally run the program as a host
+Click the green Code button on this page, 
+Download zip file, uncompress it. 
+(or run `git clone` if you have `git` installed on your computer.)\
+After that,\
 Run `flask_app.py` and open the link in the browser ( such as 
 `http://127.0.0.1:5000` ) and enjoy!
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # FT_EXPLAINED
-Contains source code for the FT_EXPLAINED web application.
-The main Python code is inside "flask_app.py" file.
+This Program is to explain how Fourier Transform is used in NMR. 
+The repository contains source code for the FT_EXPLAINED web application.
+The main program together with its Python code is inside `flask_app.py` file.
 Web pages are in "templates" directory, and style sheets in "static" directory.
 The app needs these requirements:
 1. [Python](https://www.python.org)

--- a/flask_app.py
+++ b/flask_app.py
@@ -109,7 +109,7 @@ def draw_freq():
     ax_FT.set_ylabel("Relative Intensity",y=0.8)
     ax_FT.set_title("4. Spectrum")
     ax_FT.tick_params(axis='y',which='both',left=True,labelleft=True)
-    ax_FT.grid(b=True,linestyle="--",which="both")
+    ax_FT.grid(visible=True,linestyle="--",which="both")
 
     colors=["green","black","red","cyan"]
     FID=np.zeros(session["nb_points"])
@@ -239,9 +239,9 @@ def step_1():
                 posmult[nn]=ii
             if ii <0:
                 negmult[nn]=ii
-        posinteg[i]=np.trapz(posmult,t)
-        neginteg[i]=np.trapz(negmult,t)
-        integ[i]=np.trapz(mult[i],t)
+        posinteg[i]=np.trapezoid(posmult,t)
+        neginteg[i]=np.trapezoid(negmult,t)
+        integ[i]=np.trapezoid(mult[i],t)
         if freq<=session["freq_min"]:
             n=i
     ax_FT.set_ylim(integ.min()-(integ.max()-integ.min())*0.05,integ.max()+(integ.max()-integ.min())*0.4)


### PR DESCRIPTION
Hello,
I am a student studying FT-NMR and wondering how Fourier Transform works in
NMR. Then I saw your program and paper.
I tried to run this on my PC using `Python 3.13.2`, and all libraries
up-to-date. It didn't work properly and raised an error showing `ax.grid` has
no attribute called `b`. I viewed [matplotlib
document](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.grid.html#matplotlib.axes.Axes.grid)
and guessed `b` may be `bold` or something other boolean. I changed it to
visible.
Then I saw some deprecation about `np.trapz`, and updated them to
`np.trapezoid`.
Finally I updated README.md for newcomers.
Hope the project to be more successful.
Authored by sgwzq at 3/6/2025
